### PR TITLE
promtail ansible role improvements

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -33,7 +33,7 @@
       when: __already_deployed.stat.exists | bool
 
 - name: Install Promtail from remote URL
-  ansible.builtin.dnf:
+  ansible.builtin.package:
     name: "{{ promtail_download_url }}"
     state: present
     disable_gpg_check: true
@@ -75,13 +75,18 @@
     - promtail_acl_log_file_permission | length > 0
     - promtail_acl_log_dir_permission | length > 0
 
+- name: Get firewalld state
+  ansible.builtin.systemd:
+    name: "firewalld"
+  register: firewalld_service_state
+
 - name: Enable firewalld rule to expose Promtail {{ promtail_http_listen_port }}/tcp port
   ansible.posix.firewalld:
     immediate: true
     permanent: true
     port: "{{ promtail_http_listen_port }}/tcp"
     state: enabled
-  when: promtail_expose_port | bool
+  when: firewalld_service_state.status.ActiveState == "active" and promtail_expose_port | bool
 
 - name: Ensure that Promtail {{ promtail_http_listen_port }}/tcp port - firewalld rule is not present
   ansible.posix.firewalld:
@@ -89,7 +94,7 @@
     permanent: true
     port: "{{ promtail_http_listen_port }}/tcp"
     state: disabled
-  when: not promtail_expose_port | bool
+  when: firewalld_service_state.status.ActiveState == "active" and not promtail_expose_port | bool
 
 - name: Flush handlers after deployment
   ansible.builtin.meta: flush_handlers

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -33,7 +33,7 @@
       when: __already_deployed.stat.exists | bool
 
 - name: Install Promtail from remote URL
-  ansible.builtin.package:
+  ansible.builtin.dnf:
     name: "{{ promtail_download_url }}"
     state: present
     disable_gpg_check: true

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -36,12 +36,18 @@
     state: absent
     autoremove: true
 
+- name: Get firewalld state
+  ansible.builtin.systemd:
+    name: "firewalld"
+  register: firewalld_service_state
+
 - name: Ensure that Promtail {{ promtail_http_listen_port }}/tcp port - firewalld rule is not present
   ansible.posix.firewalld:
     immediate: true
     permanent: true
     port: "{{ promtail_http_listen_port }}/tcp"
     state: disabled
+  when: firewalld_service_state.status.ActiveState == "active"
 
 - name: Remove Promtail directories"
   ansible.builtin.file:


### PR DESCRIPTION
I found the following improvements interesting for this role:
1. Make promtail installation dependant to the package manager of the OS
2. Only expose promtail port if firewalld is enabled