### PR TITLE
ubuntu and debian support

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         distro:
           - rockylinux9
+          - ubuntu2204
+          - debian12
 
     steps:
       - name: Check out the codebase.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,16 @@
 ---
 # defaults file for promtail
 promtail_version: "latest"
-promtail_arch: "x86_64"
 promtail_http_listen_port: 9080
 promtail_http_listen_address: "0.0.0.0"
-promtail_expose_port: true
+promtail_expose_port: false
 promtail_positions_path: "/var/lib/promtail"
-promtail_systemd_journal_access: true
-promtail_download_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-{{ promtail_version }}.{{ promtail_arch }}.rpm"
+
+promtail_user_append_groups:
+  - "systemd-journal"
+
+promtail_download_url_rpm: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-{{ promtail_version }}.{{ __promtail_arch }}.rpm"
+promtail_download_url_deb: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail_{{ promtail_version }}_{{ __promtail_arch }}.deb"
 
 # default variables for /etc/promtail/config.yml
 promtail_server:
@@ -17,42 +20,44 @@ promtail_server:
 promtail_positions:
   filename: "{{ promtail_positions_path }}/positions.yaml"
 
-promtail_clients:
-  - url: http://localhost:3100/loki/api/v1/push
+promtail_clients: []
+# promtail_clients:
+#   - url: http://localhost:3100/loki/api/v1/push
 
-promtail_scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: secure
-          instance: "{{ ansible_fqdn }}"
-          __path__: /var/log/secure
-      - targets:
-          - localhost
-        labels:
-          job: messages
-          instance: "{{ ansible_fqdn }}"
-          __path__: /var/log/messages
-      - targets:
-          - localhost
-        labels:
-          job: cron
-          instance: "{{ ansible_fqdn }}"
-          __path__: /var/log/cron
-      - targets:
-          - localhost
-        labels:
-          job: dnf
-          instance: "{{ ansible_fqdn }}"
-          __path__: /var/log/dnf.log
-      - targets:
-          - localhost
-        labels:
-          job: boot
-          instance: "{{ ansible_fqdn }}"
-          __path__: /var/log/boot.log
+promtail_scrape_configs: []
+# promtail_scrape_configs:
+#   - job_name: system
+#     static_configs:
+#       - targets:
+#           - localhost
+#         labels:
+#           job: secure
+#           instance: "{{ ansible_fqdn }}"
+#           __path__: /var/log/secure
+#       - targets:
+#           - localhost
+#         labels:
+#           job: messages
+#           instance: "{{ ansible_fqdn }}"
+#           __path__: /var/log/messages
+#       - targets:
+#           - localhost
+#         labels:
+#           job: cron
+#           instance: "{{ ansible_fqdn }}"
+#           __path__: /var/log/cron
+#       - targets:
+#           - localhost
+#         labels:
+#           job: dnf
+#           instance: "{{ ansible_fqdn }}"
+#           __path__: /var/log/dnf.log
+#       - targets:
+#           - localhost
+#         labels:
+#           job: boot
+#           instance: "{{ ansible_fqdn }}"
+#           __path__: /var/log/boot.log
 
 # not set by default
 # promtail_limits_config:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,11 +5,26 @@ galaxy_info:
   description: Manage Grafana Promtail Application
   company: VoidQuark
   license: MIT
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.10"
   platforms:
     - name: EL
       versions:
-        - "8"
         - "9"
+        - "8"
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+  galaxy_tags:
+    - promtail
+    - grafana
+    - logging
+    - grafana
+    - monitoring
 
 dependencies: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,13 +3,13 @@
   hosts: all
   vars:
     promtail_scrape_configs:
-      - job_name: system
+      - job_name: test
         static_configs:
           - targets:
               - localhost
             labels:
-              job: dnf
+              job: test
               instance: "{{ ansible_fqdn }}"
-              __path__: /var/log/dnf.log
+              __path__: /var/log/lastlog
   roles:
     - role: voidquark.promtail

--- a/tasks/acl_configuration.yml
+++ b/tasks/acl_configuration.yml
@@ -88,13 +88,13 @@
         path: "/var/log/dummy_promtail_acl"
         state: directory
         owner: "promtail"
-        group: "promtail"
+        group: "root"
         mode: "0750"
 
     - name: Create dummy empty log file for logrotate ACL configuration to work
       ansible.builtin.copy:
         content: ""
         dest: "/var/log/dummy_promtail_acl/dummy_promtail_acl.log"
-        owner: promtail
-        group: promtail
+        owner: "promtail"
+        group: "root"
         mode: 0600

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -32,20 +32,22 @@
       register: __current_deployed_version
       when: __already_deployed.stat.exists | bool
 
-- name: Install Promtail from remote URL
-  ansible.builtin.dnf:
-    name: "{{ promtail_download_url }}"
-    state: present
-    disable_gpg_check: true
-  notify: restart promtail
-  when: __current_deployed_version.stdout is not defined or promtail_version not in __current_deployed_version.stdout
+- name: Include RedHat/Rocky setup
+  ansible.builtin.include_tasks:
+    file: setup-RedHat.yml
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+- name: Include Debian/Ubuntu setup
+  ansible.builtin.include_tasks:
+    file: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
 
 - name: Ensure that Promtail position path exists
   ansible.builtin.file:
     path: "{{ promtail_positions_path }}"
     state: directory
     owner: "promtail"
-    group: "promtail"
+    group: "root"
     mode: "0750"
 
 - name: Template Promtail config - /etc/promtail/config.yml
@@ -53,26 +55,29 @@
     src: "config.yml.j2"
     dest: "/etc/promtail/config.yml"
     owner: "promtail"
-    group: "promtail"
+    group: "root"
     mode: "0644"
     validate: "/usr/bin/promtail -check-syntax -config.file %s"
   notify: restart promtail
 
-- name: Add the Promtail system user to systemd-journal group
+- name: Add the Promtail system user to additional group
   ansible.builtin.user:
     name: "promtail"
-    groups: "systemd-journal"
+    groups: "{{ group_name }}"
     system: true
     append: true
     create_home: false
     state: present
-  when: promtail_systemd_journal_access | bool
+  loop: "{{ promtail_user_append_groups }}"
+  loop_control:
+    loop_var: group_name
+  when: promtail_user_append_groups | length > 0
 
 - name: Include Promtail ACL permission configuration
   ansible.builtin.include_tasks:
     file: "acl_configuration.yml"
   when:
-    - promtail_scrape_configs is defined
+    - promtail_scrape_configs | length > 0
 
 - name: Get firewalld state
   ansible.builtin.systemd:
@@ -85,7 +90,9 @@
     permanent: true
     port: "{{ promtail_http_listen_port }}/tcp"
     state: enabled
-  when: __firewalld_service_state.status.ActiveState == "active" and promtail_expose_port | bool
+  when:
+    - __firewalld_service_state.status.ActiveState == "active"
+    - promtail_expose_port | bool
 
 - name: Ensure that Promtail firewalld rule is not present - tcp port {{ promtail_http_listen_port }}
   ansible.posix.firewalld:
@@ -93,7 +100,9 @@
     permanent: true
     port: "{{ promtail_http_listen_port }}/tcp"
     state: disabled
-  when: __firewalld_service_state.status.ActiveState == "active" and not promtail_expose_port | bool
+  when:
+    - __firewalld_service_state.status.ActiveState == "active"
+    - not promtail_expose_port | bool
 
 - name: Flush handlers after deployment
   ansible.builtin.meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # tasks file for promtail
+- name: Include OS specific variables
+  ansible.builtin.include_vars:
+    file: "{{ ansible_os_family }}.yml"
 
 - name: Deploy Promtail service
   ansible.builtin.include_tasks:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,0 +1,13 @@
+---
+- name: APT - Ensure that ACL is present
+  ansible.builtin.apt:
+    name: "acl"
+    state: present
+    update_cache: yes
+
+- name: APT - Install Promtail
+  ansible.builtin.apt:
+    deb: "{{ promtail_download_url_deb }}"
+    state: present
+  notify: restart promtail
+  when: __current_deployed_version.stdout is not defined or promtail_version not in __current_deployed_version.stdout

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,0 +1,9 @@
+---
+- name: DNF - Install Promtail from remote URL
+  ansible.builtin.dnf:
+    name: "{{ promtail_download_url_rpm }}"
+    state: present
+    disable_gpg_check: true
+  notify: restart promtail
+  when:
+    - __current_deployed_version.stdout is not defined or promtail_version not in __current_deployed_version.stdout

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -33,13 +33,24 @@
         | list
       }}
 
-- name: Remove ACL Permission for log dir
+- name: Remove ACL Permission for log dirs - default
   ansible.posix.acl:  # noqa ignore-errors
     path: "{{ log_dir }}"
     recursive: true
     entity: promtail
     etype: user
     default: true
+    state: absent
+  loop: "{{ __promtail_acl_log_dirs }}"
+  loop_control:
+    loop_var: log_dir
+  ignore_errors: true
+
+- name: Remove ACL permission for log dirs
+  ansible.posix.acl:  # noqa ignore-errors
+    path: "{{ log_dir }}"
+    entity: promtail
+    etype: user
     state: absent
   loop: "{{ __promtail_acl_log_dirs }}"
   loop_control:
@@ -62,6 +73,13 @@
     name: "promtail"
     state: absent
     autoremove: true
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+- name: Uninstall Promtail deb package
+  ansible.builtin.apt:
+    name: "promtail"
+    state: absent
+  when: ansible_os_family == 'Debian'
 
 - name: Ensure that Promtail firewalld rule is not present - tcp port {{ promtail_http_listen_port }}
   ansible.posix.firewalld:  # noqa ignore-errors

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,5 @@
+---
+__promtail_arch_map:
+  x86_64: 'amd64'
+
+__promtail_arch: "{{ __promtail_arch_map[ansible_architecture] | default(ansible_architecture) }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+__promtail_arch: "{{ ansible_architecture }}"


### PR DESCRIPTION
- add support for Ubuntu and Debian
- arch is auto detected. Removed `promtail_arch` variable.
- `promtail_systemd_journal_access` replaced with `promtail_user_append_groups`. Now it support multiple groups.
- `promtail_clients` is unset by default
- `promtail_scrape_configs` is unset by default
- molecule testing include also Ubuntu and Debian